### PR TITLE
Update README.md run configurations IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Ensure that JDK 8 is installed on the computer before proceeding.
 ### From IntelliJ
 1. Import the project as a Gradle Project, ensuring that the project format is directory based.
 1. Premade run configurations can be found in the runConfigurations folder. Simply copy the folder to inside the .idea folder.
+1. After copying, head to File--> Close Project and then reopen the project right after to get IntelliJ to detect the new run configurations.
 1. Select the desired run configuration from the dropdown menu beside the green "run" triangle.
 1. To run regular mode, click the green "run" triangle.
 1. To run debug mode, click the bug to the right of the green "run" triangle.


### PR DESCRIPTION
I tried using the pre-existing run configurations for IntelliJ as instructed in the README and found that you had to reload the project to get the configurations detected. I added this to the instructions.

## Summary of Changes
- Added step that instructs reloading the IntelliJ project to detect run configurations.

## Testing Performed
**Environment**: IntelliJ IDEA 2018.3 on Windows 10

