### PR TITLE
Fix double subsystem initialization

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/subsystems/Bling.java
+++ b/src/main/java/ca/team2706/frc/robot/subsystems/Bling.java
@@ -18,10 +18,7 @@ public class Bling extends Subsystem {
     private static Bling currentInstance;
 
     public static Bling getInstance() {
-        if (currentInstance == null) {
-            init();
-        }
-
+        init();
         return currentInstance;
     }
 
@@ -29,7 +26,9 @@ public class Bling extends Subsystem {
      * Initializes a new bling object.
      */
     public static void init() {
-        currentInstance = new Bling();
+        if (currentInstance == null) {
+            currentInstance = new Bling();
+        }
     }
 
     // All of the pattern numbers

--- a/src/main/java/ca/team2706/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/ca/team2706/frc/robot/subsystems/DriveBase.java
@@ -22,10 +22,7 @@ public class DriveBase extends Subsystem {
     private static DriveBase currentInstance;
 
     public static DriveBase getInstance() {
-        if (currentInstance == null) {
-            init();
-        }
-
+        init();
         return currentInstance;
     }
 
@@ -33,7 +30,9 @@ public class DriveBase extends Subsystem {
      * Initializes a new drive base object.
      */
     public static void init() {
-        currentInstance = new DriveBase();
+        if (currentInstance == null) {
+            currentInstance = new DriveBase();
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary of Changes
As I brought up in #36, subsystems might be initialized twice.
Resolved this by adding a null check.
Fixes #36.


## Testing Performed
Works as before, without the double-init bug
**Environment**:  Plyboy

