### PR TITLE
Better drivebase mocking

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/config/Config.java
+++ b/src/main/java/ca/team2706/frc/robot/config/Config.java
@@ -171,7 +171,7 @@ public class Config {
         try (BufferedWriter writer = Files.newBufferedWriter(SAVE_FILE)) {
             writer.write(writable);
         } catch (IOException e) {
-            DriverStation.reportWarning("Unable to save fluid constants to file.", true);
+            DriverStation.reportWarning("Unable to save fluid constants to file.", false);
         }
     }
 

--- a/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
+++ b/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
@@ -35,6 +35,7 @@ public class DriveBaseTest {
     @Mocked(stubOutClassInitialization = true)
     private CTREJNIWrapper jni;
 
+
     private MotControllerJNI motControllerJNI;
 
     @Injectable

--- a/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
+++ b/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
@@ -1,6 +1,5 @@
 package ca.team2706.frc.robot.subsystems;
 
-import ca.team2706.frc.robot.sensors.AnalogSelector;
 import com.ctre.phoenix.CTREJNIWrapper;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 import com.ctre.phoenix.motorcontrol.SensorCollection;
@@ -18,35 +17,35 @@ import static org.junit.Assert.assertEquals;
 
 public class DriveBaseTest {
 
-    @Tested
+    @Tested(stubOutClassInitialization = true)
     private DriveBase driveBase;
 
-    @Mocked
+    @Mocked(stubOutClassInitialization = true)
     private WPI_TalonSRX talon;
 
-    @Mocked
+    @Mocked(stubOutClassInitialization = true)
     private PWM pwm;
 
-    @Mocked
+    @Mocked(stubOutClassInitialization = true)
     private AnalogInput analogInput;
 
-    @Mocked
+    @Mocked(stubOutClassInitialization = true)
     private PigeonIMU pigeon;
 
-    @Mocked
+    @Mocked(stubOutClassInitialization = true)
     private DifferentialDrive differentialDrive;
 
     @Mocked(stubOutClassInitialization = true)
     private CTREJNIWrapper jni;
 
-    @Mocked
+    @Mocked(stubOutClassInitialization = true)
     private MotControllerJNI motControllerJNI;
 
     @Injectable
     private SensorCollection sensorCollection;
 
     @Before
-    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+    public void setUp() {
         new Expectations() {{
             talon.getSensorCollection();
             result = sensorCollection;

--- a/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
+++ b/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
@@ -35,7 +35,7 @@ public class DriveBaseTest {
     @Mocked(stubOutClassInitialization = true)
     private CTREJNIWrapper jni;
 
-
+    @Mocked(stubOutClassInitialization = true)
     private MotControllerJNI motControllerJNI;
 
     @Injectable

--- a/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
+++ b/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
@@ -20,25 +20,21 @@ public class DriveBaseTest {
     @Tested
     private DriveBase driveBase;
 
-    @Mocked(stubOutClassInitialization = true)
+    @Mocked
     private WPI_TalonSRX talon;
 
-    @Mocked(stubOutClassInitialization = true)
     private PWM pwm;
 
-    @Mocked(stubOutClassInitialization = true)
     private AnalogInput analogInput;
 
     @Mocked(stubOutClassInitialization = true)
     private PigeonIMU pigeon;
 
-    @Mocked(stubOutClassInitialization = true)
     private DifferentialDrive differentialDrive;
 
     @Mocked(stubOutClassInitialization = true)
     private CTREJNIWrapper jni;
 
-    @Mocked(stubOutClassInitialization = true)
     private MotControllerJNI motControllerJNI;
 
     @Injectable

--- a/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
+++ b/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
 
 public class DriveBaseTest {
 
-    @Tested(stubOutClassInitialization = true)
+    @Tested
     private DriveBase driveBase;
 
     @Mocked(stubOutClassInitialization = true)

--- a/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
+++ b/src/test/java/ca/team2706/frc/robot/subsystems/DriveBaseTest.java
@@ -7,6 +7,7 @@ import com.ctre.phoenix.motorcontrol.SensorCollection;
 import com.ctre.phoenix.motorcontrol.can.MotControllerJNI;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 import com.ctre.phoenix.sensors.PigeonIMU;
+import edu.wpi.first.wpilibj.AnalogInput;
 import edu.wpi.first.wpilibj.PWM;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import mockit.*;
@@ -20,25 +21,25 @@ public class DriveBaseTest {
     @Tested
     private DriveBase driveBase;
 
-    @Mocked(stubOutClassInitialization = true)
+    @Mocked
     private WPI_TalonSRX talon;
 
-    @Mocked(stubOutClassInitialization = true)
+    @Mocked
     private PWM pwm;
 
-    @Mocked(stubOutClassInitialization = true)
-    private AnalogSelector analogSelector;
+    @Mocked
+    private AnalogInput analogInput;
 
-    @Mocked(stubOutClassInitialization = true)
+    @Mocked
     private PigeonIMU pigeon;
 
-    @Mocked(stubOutClassInitialization = true)
+    @Mocked
     private DifferentialDrive differentialDrive;
 
     @Mocked(stubOutClassInitialization = true)
     private CTREJNIWrapper jni;
 
-    @Mocked(stubOutClassInitialization = true)
+    @Mocked
     private MotControllerJNI motControllerJNI;
 
     @Injectable


### PR DESCRIPTION
## Summary of Changes
- Disable printing stacktrace for when fluid constants can't be saved.
- Change drivebase tests so that they mock the `AnalogInput` class instead of our own `AnalogSelector` class as is recommended by JMockit documentation.
- Removed `throws` clauses on setUp method for drivebase tests.

## Testing Performed
**Environment**: Tests were run and passed on Azure.

