### PR TITLE
Add windows CI for azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,17 +8,34 @@ trigger:
     include:
       - refs/heads/*
 
-pool:
-  vmImage: 'Ubuntu-16.04'
 
-container: wpilib/roborio-cross-ubuntu:2019-18.04
+jobs:
+  - job: Windows
+    pool:
+      vmImage: 'vs2017-win2016'
+    steps:
+      - task: Gradle@2
+        inputs:
+          workingDirectory: ''
+          gradleWrapperFile: 'gradlew'
+          gradleOptions: '-Xmx3072m'
+          javaHomeOption: 'JDKVersion'
+          jdkVersionOption: '1.11'
+          jdkArchitectureOption: 'x64'
+          publishJUnitResults: true
+          testResultsFiles: '**/TEST-*.xml'
+          tasks: 'build'
+  - job: Linux
+    pool:
+      vmImage: 'ubuntu-16.04'
+    container: wpilib/roborio-cross-ubuntu:2019-18.04
+    steps:
+      - task: Gradle@2
+        inputs:
+          workingDirectory: ''
+          gradleWrapperFile: 'gradlew'
+          gradleOptions: '-Xmx3072m'
+          publishJUnitResults: true
+          testResultsFiles: '**/TEST-*.xml'
+          tasks: 'build'
 
-steps:
-  - task: Gradle@2
-    inputs:
-      workingDirectory: ''
-      gradleWrapperFile: 'gradlew'
-      gradleOptions: '-Xmx3072m'
-      publishJUnitResults: true
-      testResultsFiles: '**/TEST-*.xml'
-      tasks: 'build'


### PR DESCRIPTION
Since the linux machine in CI uses a docker image to run the tests, it can behave
a little funky.

This is why I thought it would be a good idea to run our tests on both windows without any emulation
as well as using the emulated roboRIO platform.

We could add Mac OS but that seems pointless.

## Summary of Changes
- Add windows job to azure CI. Tests will now be run in parallel on Windows and Linux using the Docker.

## Testing Performed
**Environment**: Azure automated testing.
The linux environment pulled the docker image correctly and actually ran the tests, the windows environment just pulled java and ran its tests too. 

