### PR TITLE
Reflection to reset subsystems

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/commands/drivebase/RotateWithGyro.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/drivebase/RotateWithGyro.java
@@ -1,7 +1,6 @@
 package ca.team2706.frc.robot.commands.drivebase;
 
 import ca.team2706.frc.robot.subsystems.DriveBase;
-import edu.wpi.first.wpilibj.command.Command;
 
 import java.util.function.Supplier;
 

--- a/src/test/java/ca/team2706/frc/robot/RobotTest.java
+++ b/src/test/java/ca/team2706/frc/robot/RobotTest.java
@@ -19,6 +19,7 @@ import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.Before;
 import org.junit.Test;
+import util.Util;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -27,6 +28,14 @@ import java.util.function.Consumer;
 import static org.junit.Assert.*;
 
 public class RobotTest {
+
+    static {
+        try {
+            Util.resetSubsystems();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
 
     private final Robot robot = new Robot();
 

--- a/src/test/java/ca/team2706/frc/robot/config/ConfigTest.java
+++ b/src/test/java/ca/team2706/frc/robot/config/ConfigTest.java
@@ -19,6 +19,7 @@ import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.Before;
 import org.junit.Test;
+import util.Util;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -106,6 +107,7 @@ public class ConfigTest {
             }};
 
 
+            Util.resetSubsystems();
             // New robot to be worked with.
             robot = new Robot();
             robot.robotInit();

--- a/src/test/java/ca/team2706/frc/robot/config/FluidConstantTest.java
+++ b/src/test/java/ca/team2706/frc/robot/config/FluidConstantTest.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import mockit.*;
 import org.junit.Before;
 import org.junit.Test;
+import util.Util;
 
 public class FluidConstantTest {
     // We'll just use a string fluid constant to test.
@@ -74,7 +75,7 @@ public class FluidConstantTest {
     private static boolean isInitialized = false;
 
     @Before
-    public void setUp() {
+    public void setUp() throws NoSuchFieldException, IllegalAccessException {
         if (!isInitialized) {
             isInitialized = true;
 
@@ -92,6 +93,7 @@ public class FluidConstantTest {
                 minTimes = 0;
             }};
 
+            Util.resetSubsystems();
             Robot robot = new Robot();
             robot.robotInit();
         }

--- a/src/test/java/ca/team2706/frc/robot/operatorfeedback/rumbler/RumblerTest.java
+++ b/src/test/java/ca/team2706/frc/robot/operatorfeedback/rumbler/RumblerTest.java
@@ -1,6 +1,5 @@
 package ca.team2706.frc.robot.operatorfeedback.rumbler;
 
-import ca.team2706.frc.robot.OI;
 import ca.team2706.frc.robot.subsystems.DriveBase;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.Joystick;
@@ -10,8 +9,8 @@ import mockit.Verifications;
 import mockit.VerificationsInOrder;
 import org.junit.Before;
 import org.junit.Test;
+import util.Util;
 
-import java.lang.reflect.Field;
 import java.time.Clock;
 
 import static org.junit.Assert.assertFalse;
@@ -30,9 +29,7 @@ public class RumblerTest {
     @Before
     public void setUp() throws NoSuchFieldException, IllegalAccessException {
         // I should re-initialize OI for each time.
-        Field currentInstanceField = OI.class.getDeclaredField("currentInstance");
-        currentInstanceField.setAccessible(true);
-        currentInstanceField.set(null, null);
+        Util.resetSubsystems();
 
         new Expectations() {{
             new Joystick(0);

--- a/src/test/java/ca/team2706/frc/robot/subsystems/SensorExtrasTest.java
+++ b/src/test/java/ca/team2706/frc/robot/subsystems/SensorExtrasTest.java
@@ -12,10 +12,10 @@ import mockit.Tested;
 import mockit.Verifications;
 import org.junit.Before;
 import org.junit.Test;
+import util.Util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.lang.reflect.Field;
 
 import static org.junit.Assert.assertEquals;
 
@@ -49,9 +49,7 @@ public class SensorExtrasTest {
 
     @Before
     public void setUp() throws NoSuchFieldException, IllegalAccessException {
-        Field field1 = SensorExtras.class.getDeclaredField("currentInstance");
-        field1.setAccessible(true);
-        field1.set(null, null);
+        Util.resetSubsystems();
     }
 
     /**

--- a/src/test/java/util/Util.java
+++ b/src/test/java/util/Util.java
@@ -1,0 +1,38 @@
+package util;
+
+import ca.team2706.frc.robot.OI;
+import ca.team2706.frc.robot.subsystems.Bling;
+import ca.team2706.frc.robot.subsystems.DriveBase;
+import ca.team2706.frc.robot.subsystems.SensorExtras;
+
+import java.lang.reflect.Field;
+
+public class Util {
+    /**
+     * Sets the currentInstance variable of all subsystems to null in order to reset them during testes.
+     *
+     * @throws NoSuchFieldException   If the field doesn't exist.
+     * @throws IllegalAccessException If the field for currentInstance is inaccessible.
+     */
+    public static void resetSubsystems() throws NoSuchFieldException, IllegalAccessException {
+        setCurrentInstanceFieldNull(Bling.class);
+        setCurrentInstanceFieldNull(OI.class);
+        setCurrentInstanceFieldNull(SensorExtras.class);
+        setCurrentInstanceFieldNull(DriveBase.class);
+        System.out.println("Reset"); // TODO remove
+    }
+
+    /**
+     * Sets the static private field to the desired value.
+     *
+     * @param classObject The class to which the field belongs.
+     * @throws NoSuchFieldException   When the field doesn't exist.
+     * @throws IllegalAccessException When the field is inaccessible.
+     */
+    private static void setCurrentInstanceFieldNull(final Class classObject) throws NoSuchFieldException, IllegalAccessException {
+        Field field = classObject.getDeclaredField("currentInstance");
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+
+}

--- a/src/test/java/util/Util.java
+++ b/src/test/java/util/Util.java
@@ -19,7 +19,6 @@ public class Util {
         setCurrentInstanceFieldNull(OI.class);
         setCurrentInstanceFieldNull(SensorExtras.class);
         setCurrentInstanceFieldNull(DriveBase.class);
-        System.out.println("Reset"); // TODO remove
     }
 
     /**


### PR DESCRIPTION
Subsystems are all now reset whenever it is requested.

Closes #78.

## Summary of Changes
- Made static `currentInstance` field resetter method.

## Testing Performed
**Environment**: Automated tests (only changing the automated tests so this is fine).

