### PR TITLE
Add handbrake command and EButton implementations

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/commands/drivebase/Handbrake.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/drivebase/Handbrake.java
@@ -1,0 +1,35 @@
+package ca.team2706.frc.robot.commands.drivebase;
+
+import ca.team2706.frc.robot.subsystems.DriveBase;
+import edu.wpi.first.wpilibj.command.Command;
+
+/**
+ * Puts the robot in brake mode when enabled
+ */
+public class Handbrake extends Command {
+
+    private boolean brake;
+
+    @Override
+    public void initialize() {
+        if(!DriveBase.getInstance().isBrakeMode()) {
+            DriveBase.getInstance().setBrakeMode(true);
+            brake = true;
+        }
+        else {
+            brake = false;
+        }
+    }
+
+    @Override
+    protected boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public void end() {
+        if(brake) {
+            DriveBase.getInstance().setBrakeMode(false);
+        }
+    }
+}

--- a/src/main/java/ca/team2706/frc/robot/input/EJoystickButton.java
+++ b/src/main/java/ca/team2706/frc/robot/input/EJoystickButton.java
@@ -1,0 +1,35 @@
+package ca.team2706.frc.robot.input;
+
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.buttons.Button;
+
+/**
+ * A {@link EButton} that gets its state from a {@link GenericHID}.
+ */
+public class EJoystickButton extends EButton {
+
+    private final GenericHID m_joystick;
+    private final int m_buttonNumber;
+
+    /**
+     * Create a joystick button for triggering commands.
+     *
+     * @param joystick     The GenericHID object that has the button (e.g. Joystick, KinectStick,
+     *                     etc)
+     * @param buttonNumber The button number (see {@link GenericHID#getRawButton(int) }
+     */
+    public EJoystickButton(GenericHID joystick, int buttonNumber) {
+        m_joystick = joystick;
+        m_buttonNumber = buttonNumber;
+    }
+
+    /**
+     * Gets the value of the joystick button.
+     *
+     * @return The value of the joystick button
+     */
+    @Override
+    public boolean get() {
+        return m_joystick.getRawButton(m_buttonNumber);
+    }
+}

--- a/src/main/java/ca/team2706/frc/robot/input/EPOVButton.java
+++ b/src/main/java/ca/team2706/frc/robot/input/EPOVButton.java
@@ -1,0 +1,46 @@
+package ca.team2706.frc.robot.input;
+
+import edu.wpi.first.wpilibj.GenericHID;
+
+/**
+ * A {@link EButton} that gets its state from a POV on a {@link GenericHID}.
+ */
+public class EPOVButton extends EButton {
+    private final GenericHID m_joystick;
+    private final int m_angle;
+    private final int m_povNumber;
+
+    /**
+     * Creates a POV button for triggering commands.
+     *
+     * @param joystick The GenericHID object that has the POV
+     * @param angle The desired angle in degrees (e.g. 90, 270)
+     * @param povNumber The POV number (see {@link GenericHID#getPOV(int)})
+     */
+    public EPOVButton(GenericHID joystick, int angle, int povNumber) {
+        m_joystick = joystick;
+        m_angle = angle;
+        m_povNumber = povNumber;
+    }
+
+    /**
+     * Creates a POV button for triggering commands.
+     * By default, acts on POV 0
+     *
+     * @param joystick The GenericHID object that has the POV
+     * @param angle The desired angle (e.g. 90, 270)
+     */
+    public EPOVButton(GenericHID joystick, int angle) {
+        this(joystick, angle, 0);
+    }
+
+    /**
+     * Checks whether the current value of the POV is the target angle.
+     *
+     * @return Whether the value of the POV matches the target angle
+     */
+    @Override
+    public boolean get() {
+        return m_joystick.getPOV(m_povNumber) == m_angle;
+    }
+}

--- a/src/test/java/ca/team2706/frc/robot/commands/drivebase/HandBrakeTest.java
+++ b/src/test/java/ca/team2706/frc/robot/commands/drivebase/HandBrakeTest.java
@@ -1,0 +1,70 @@
+package ca.team2706.frc.robot.commands.drivebase;
+
+import ca.team2706.frc.robot.subsystems.DriveBase;
+import com.ctre.phoenix.CTREJNIWrapper;
+import com.ctre.phoenix.motorcontrol.SensorCollection;
+import com.ctre.phoenix.motorcontrol.can.MotControllerJNI;
+import com.ctre.phoenix.sensors.PigeonIMU;
+import edu.wpi.first.wpilibj.AnalogInput;
+import edu.wpi.first.wpilibj.Notifier;
+import edu.wpi.first.wpilibj.PWM;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import mockit.Injectable;
+import mockit.Mocked;
+import mockit.Tested;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HandBrakeTest {
+
+    @Tested
+    private Handbrake handbrake;
+
+    @Mocked
+    private PWM pwm;
+
+    @Mocked
+    private AnalogInput analogInput;
+
+    @Mocked(stubOutClassInitialization = true)
+    private PigeonIMU pigeon;
+
+    @Mocked
+    private DifferentialDrive differentialDrive;
+
+    @Mocked(stubOutClassInitialization = true)
+    private CTREJNIWrapper jni;
+
+    @Mocked(stubOutClassInitialization = true)
+    private MotControllerJNI motControllerJNI;
+
+    @Mocked
+    private Notifier notifier;
+
+    @Injectable
+    private SensorCollection sensorCollection;
+
+    @Before
+    public void setUp() {
+        DriveBase.getInstance().setBrakeMode(false);
+    }
+
+    /**
+     * Tests that hand brake enables and disables correctly
+     */
+    @Test
+    public void testHandBrake() {
+        assertFalse(DriveBase.getInstance().isBrakeMode());
+
+        handbrake.initialize();
+
+        assertTrue(DriveBase.getInstance().isBrakeMode());
+
+        handbrake.end();
+
+        assertFalse(DriveBase.getInstance().isBrakeMode());
+    }
+}


### PR DESCRIPTION
## Summary of Changes
Handbrake command that puts the drive base into brake mode when it is running
EButton implementations don't need tests because they're copies of WPILib classes except extending EButton

## Testing Performed
**Environment**:  Plyboy

