### PR TITLE
Fix motion magic reset

### DIFF
--- a/src/test/java/ca/team2706/frc/robot/commands/drivebase/MotionMagicTest.java
+++ b/src/test/java/ca/team2706/frc/robot/commands/drivebase/MotionMagicTest.java
@@ -18,6 +18,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import mockit.*;
 import org.junit.Before;
 import org.junit.Test;
+import util.Util;
 
 import static org.junit.Assert.*;
 
@@ -57,6 +58,7 @@ public class MotionMagicTest {
 
     @Before
     public void setUp() throws NoSuchFieldException, IllegalAccessException {
+        Util.resetSubsystems();
         new Expectations() {{
             talon.getSensorCollection();
             result = sensorCollection;


### PR DESCRIPTION
## Summary of Changes
- Add one single line to fix the motion magic tests, which weren't resetting subsystems properly.


## Testing Performed
**Environment**: Automated testing

