### PR TITLE
Small improvement to ArcadeDriveWithJoystick tests

### DIFF
--- a/src/test/java/ca/team2706/frc/robot/commands/drivebase/ArcadeDriveWithJoystickTest.java
+++ b/src/test/java/ca/team2706/frc/robot/commands/drivebase/ArcadeDriveWithJoystickTest.java
@@ -18,6 +18,7 @@ import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.Before;
 import org.junit.Test;
+import util.Util;
 
 public class ArcadeDriveWithJoystickTest {
     @Mocked
@@ -47,18 +48,25 @@ public class ArcadeDriveWithJoystickTest {
     @Injectable
     private SensorCollection sensorCollection;
 
-    @Mocked
+    @Injectable
     private Joystick joy1;
 
-    @Mocked
+    @Injectable
     private Joystick joy2;
 
+    private static boolean initialized = false;
+
     @Before
-    public void setUp() {
-        new Expectations() {{
-            talon.getSensorCollection();
-            result = sensorCollection;
-        }};
+    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+        if (!initialized) {
+            initialized = true;
+
+            Util.resetSubsystems();
+            new Expectations() {{
+                talon.getSensorCollection();
+                result = sensorCollection;
+            }};
+        }
     }
 
     /**


### PR DESCRIPTION
I noticed that the ArcadeDrivewWithJoystick tests could be improved by using injectable instead of mocking, so I did.

## Summary of Changes
- Changed the uses of `@Mocked` to `@Injectable` in places where it would work.
- Ensured that the ArcadeDriveWithJoystick tests actually reset subsystems properly so that they would get the new sensor collections for sure.


## Testing Performed
**Environment**: Automated testing.

