### PR TITLE
More efficient FluidButton

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/input/FluidButton.java
+++ b/src/main/java/ca/team2706/frc/robot/input/FluidButton.java
@@ -20,7 +20,8 @@ public class FluidButton extends EButton {
     public static final int POV_NUMBER = 0;
 
     private final GenericHID m_joystick;
-    private final FluidConstant<String> joystickPort;
+    private int joystickPort;
+    private XboxValue.XboxInputType inputType;
 
     /**
      * Constructs a FluidButton with the given GenericHID interface and action binding.
@@ -30,7 +31,13 @@ public class FluidButton extends EButton {
      */
     public FluidButton(GenericHID genericHID, FluidConstant<String> actionBinding) {
         m_joystick = genericHID;
-        this.joystickPort = actionBinding;
+        this.joystickPort = XboxValue.getPortFromFluidConstant(actionBinding);
+
+        actionBinding.addChangeListener((oldValue, newValue) -> {
+            XboxValue value = XboxValue.getXboxValueFromNTKey(newValue);
+            this.joystickPort = value.getPort();
+            this.inputType = value.getInputType();
+        });
     }
 
     /**
@@ -45,19 +52,20 @@ public class FluidButton extends EButton {
 
     @Override
     public boolean get() {
-        XboxValue port = XboxValue.getXboxValueFromNTKey(joystickPort.value());
+        final boolean value;
 
-        boolean value = false;
-
-        switch (port.getInputType()) {
+        switch (inputType) {
             case Axis:
-                value = Math.abs(m_joystick.getRawAxis(port.getPort())) >= MIN_AXIS_ACTIVATION;
+                value = Math.abs(m_joystick.getRawAxis(joystickPort)) >= MIN_AXIS_ACTIVATION;
                 break;
             case Button:
-                value = m_joystick.getRawButton(port.getPort());
+                value = m_joystick.getRawButton(joystickPort);
                 break;
             case POV:
-                value = m_joystick.getPOV(POV_NUMBER) == port.getPort();
+                value = m_joystick.getPOV(POV_NUMBER) == joystickPort;
+                break;
+            default:
+                value = false;
                 break;
         }
 

--- a/src/main/java/ca/team2706/frc/robot/input/FluidButton.java
+++ b/src/main/java/ca/team2706/frc/robot/input/FluidButton.java
@@ -31,13 +31,21 @@ public class FluidButton extends EButton {
      */
     public FluidButton(GenericHID genericHID, FluidConstant<String> actionBinding) {
         m_joystick = genericHID;
-        this.joystickPort = XboxValue.getPortFromFluidConstant(actionBinding);
+        updatePortAndInputType(XboxValue.getXboxValueFromFluidConstant(actionBinding));
 
         actionBinding.addChangeListener((oldValue, newValue) -> {
-            XboxValue value = XboxValue.getXboxValueFromNTKey(newValue);
-            this.joystickPort = value.getPort();
-            this.inputType = value.getInputType();
+            updatePortAndInputType(XboxValue.getXboxValueFromNTKey(newValue));
         });
+    }
+
+    /**
+     * Updates the port and input type for this button.
+     *
+     * @param value The XboxValue button binding.
+     */
+    private void updatePortAndInputType(XboxValue value) {
+        this.joystickPort = value.getPort();
+        this.inputType = value.getInputType();
     }
 
     /**


### PR DESCRIPTION
It's possible that part of the reason that the robot is overruning it's loop time was because
the FluidButton always looks up the Xbox button port each time it runs the `get()` method.

Fixed by using the FluidConstant listener instead.

## Summary of Changes
- `FluidButton` doesn't poll the joystick port from the fluid constant each time `get()` is called.
- Instead, listeners are used to update the value in memory when it changes.

## Testing Performed
**Environment**: Automated testing.

Awaiting more testing.

