### PR TITLE
Add timeout to EjectHatch

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/commands/intake/hatch/EjectHatch.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/intake/hatch/EjectHatch.java
@@ -20,14 +20,14 @@ public class EjectHatch extends CommandGroup {
      */
     public EjectHatch(LiftPosition elevatorPosition) {
         addSequential(new InstantCommand(() -> elevatorPosition.setPosition(Lift.getInstance().getLiftHeight())));
-        // Make sure lift is high enough.
+        // Make sure lift is high enough. Timeout after 0.75 seconds in case it's blocked.
         addSequential(new ConditionalCommand(new MoveLiftToPosition(0.7, () -> 0.05 - Config.SUBTRACT_LIFT_HEIGHT)) {
             @Override
             protected boolean condition() {
                 // Make sure that we're above the minimum hatch eject height before going.
                 return Lift.getInstance().getLiftHeight() < -Config.SUBTRACT_LIFT_HEIGHT + 0.05;
             }
-        });
+        }, 0.75);
         addSequential(new MovePlunger(MovePlunger.DesiredState.DEPLOYED)); // Put plunger out and wait (timed command).
         // Move lift down slightly
         addSequential(new MoveLiftToPosition(0.5, () -> Lift.getInstance().getLiftHeight() + Config.SUBTRACT_LIFT_HEIGHT));


### PR DESCRIPTION
In case the elevator doesn't reach the height it needs to after being too
low to deploy a hatch, it was thought to be a good idea to add a timeout on this
raise command.

## Summary of Changes
- Add timeout of 0.75 seconds in case the lift doesn't raise (gets blocked on something) during hatch eject.

## Testing Performed
**Environment:** Practice bot (cosmobot)
Tried the value and saw the timeout being used in places where the lift didn't rise enough. 