### PR TITLE
Adjust intake hatch lift speed

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/OI.java
+++ b/src/main/java/ca/team2706/frc/robot/OI.java
@@ -124,7 +124,7 @@ public class OI {
         new FluidButton(controlStick, Config.TOGGLE_RING_LIGHT_BINDING)
                 .whenPressed(new ToggleRingLight());
         new FluidButton(controlStick, Config.SLIGHTLY_LIFT_LIFT_BINDING)
-                .whenPressed(new MoveLiftToPosition(0.5, () -> Lift.getInstance().getLiftHeight() + 1.1));
+                .whenPressed(new MoveLiftToPosition(0.7, () -> Lift.getInstance().getLiftHeight() + 1.1));
 
         // ---- Driver controls ----
 


### PR DESCRIPTION
During drive practice we saw that it may be useful to lift the hatch a
little faster while intaking it. Increased value from 0.5 to 0.7.

## Summary of Changes
- Increased lift hatch speed value by 0.2, from 0.5 to 0.7 speed.

## Testing Performed
**Environment**: Practice bot (cosmobot)
Used during drive practice, we liked the faster value. Nothing broke. 

