### PR TITLE
Orient Robot based on Autonomous Mode

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/Robot.java
+++ b/src/main/java/ca/team2706/frc/robot/Robot.java
@@ -14,7 +14,9 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -24,6 +26,7 @@ public class Robot extends TimedRobot {
     private boolean isInitialized;
 
     private Command[] commands;
+    private Map<Integer, Integer> selectorOrientation;
 
     private static Robot latestInstance;
 
@@ -75,9 +78,12 @@ public class Robot extends TimedRobot {
                 null,                                                                      // 1
                 null,                                                                      // 2
                 OI.getInstance().driveCommand,                                             // 3
-                new DriveOffHab(),                                                         // 4
-                new LevelOneCentreHatch(),                                                 // 5
+                OI.getInstance().driveCommand,                                             // 4
+                new DriveOffHab(),                                                         // 5
+                new LevelOneCentreHatch(),                                                 // 6
         };
+
+        selectorOrientation = Map.of(4,  270);
     }
 
     /**
@@ -151,6 +157,8 @@ public class Robot extends TimedRobot {
         final int index = DriveBase.getInstance().getAnalogSelectorIndex();
 
         Log.d("Selector switch set to " + index);
+
+        DriveBase.getInstance().resetAbsoluteGyro(selectorOrientation.getOrDefault(index, (int)(double)Config.ROBOT_START_ANGLE.value()));
 
         // Check to see if the command exists in the desired index
         if (index < commands.length && commands[index] != null) {

--- a/src/main/java/ca/team2706/frc/robot/Robot.java
+++ b/src/main/java/ca/team2706/frc/robot/Robot.java
@@ -14,7 +14,6 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -83,7 +82,7 @@ public class Robot extends TimedRobot {
                 new LevelOneCentreHatch(),                                                 // 6
         };
 
-        selectorOrientation = Map.of(4,  270);
+        selectorOrientation = Map.of(4, 270);
     }
 
     /**
@@ -158,7 +157,7 @@ public class Robot extends TimedRobot {
 
         Log.d("Selector switch set to " + index);
 
-        DriveBase.getInstance().resetAbsoluteGyro(selectorOrientation.getOrDefault(index, (int)(double)Config.ROBOT_START_ANGLE.value()));
+        DriveBase.getInstance().resetAbsoluteGyro(selectorOrientation.getOrDefault(index, (int) (double) Config.ROBOT_START_ANGLE.value()));
 
         // Check to see if the command exists in the desired index
         if (index < commands.length && commands[index] != null) {

--- a/src/main/java/ca/team2706/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/ca/team2706/frc/robot/subsystems/DriveBase.java
@@ -157,13 +157,6 @@ public class DriveBase extends Subsystem {
         motionProfilePointStreamRight = new BufferedTrajectoryPointStream();
 
         resetAbsoluteGyro();
-
-        // Reset absolute gyro when robot goes into autonomous for the first time in a real match
-        Robot.setOnStateChange(robotState -> {
-            if (robotState == RobotState.AUTONOMOUS && DriverStation.getInstance().isFMSAttached()) {
-                resetAbsoluteGyro();
-            }
-        });
     }
 
     /**
@@ -922,7 +915,15 @@ public class DriveBase extends Subsystem {
      * 0 degrees.
      */
     public void resetAbsoluteGyro() {
-        savedAngle = Config.ROBOT_START_ANGLE.value();
+        resetAbsoluteGyro(Config.ROBOT_START_ANGLE.value());
+    }
+
+    /**
+     * Resets the absolute gyro to a certain angle
+     * @param savedAngle The angle from 0 to 360
+     */
+    public void resetAbsoluteGyro(double savedAngle) {
+        this.savedAngle = savedAngle;
         gyro.setYaw(0, Config.CAN_SHORT);
     }
 

--- a/src/main/java/ca/team2706/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/ca/team2706/frc/robot/subsystems/DriveBase.java
@@ -1,7 +1,5 @@
 package ca.team2706.frc.robot.subsystems;
 
-import ca.team2706.frc.robot.Robot;
-import ca.team2706.frc.robot.RobotState;
 import ca.team2706.frc.robot.Sendables;
 import ca.team2706.frc.robot.config.Config;
 import ca.team2706.frc.robot.logging.Log;
@@ -920,6 +918,7 @@ public class DriveBase extends Subsystem {
 
     /**
      * Resets the absolute gyro to a certain angle
+     *
      * @param savedAngle The angle from 0 to 360
      */
     public void resetAbsoluteGyro(double savedAngle) {

--- a/src/test/java/ca/team2706/frc/robot/RobotTest.java
+++ b/src/test/java/ca/team2706/frc/robot/RobotTest.java
@@ -237,7 +237,7 @@ public class RobotTest {
      * Tests whether the absolute gyro is reset when in a match
      */
     @Test
-    public void testAbsoluteResetOn() {
+    public void testAbsoluteReset() {
         new Expectations() {{
             driverStation.isFMSAttached();
             result = true;
@@ -253,25 +253,6 @@ public class RobotTest {
         }};
     }
 
-    /**
-     * Tests whether the absolute gyro is reset when not in a match
-     */
-    @Test
-    public void testAbsoluteResetOff() {
-        new Expectations() {{
-            driverStation.isFMSAttached();
-            result = false;
-        }};
-
-        robot.robotInit();
-
-        robot.autonomousInit();
-
-        new Verifications() {{
-            pigeon.setYaw(0, anyInt);
-            times = 2;
-        }};
-    }
 
     /**
      * Tests that the commands are correctly set and run
@@ -290,6 +271,8 @@ public class RobotTest {
         EmptyCommand b = new EmptyCommand();
         EmptyCommand c = new EmptyCommand();
         EmptyCommand d = new EmptyCommand();
+
+        robot.robotInit();
 
         setCommands(robot, a, b, null, c, d);
 
@@ -336,8 +319,7 @@ public class RobotTest {
             result = true;
         }};
 
-        // Will result in
-        OI.init();
+        robot.robotInit();
 
         EmptyCommand a = new EmptyCommand();
 


### PR DESCRIPTION
## Summary of Changes
- Reset absolute gyro at start of match
- Certain selector keys correspond to the starting absolute gyro
- Set the absolute gyro to the starting heading on autonomous start

## Testing Performed
**Environment**: Practice bot

