### PR TITLE
Remove drive command from auto

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/Robot.java
+++ b/src/main/java/ca/team2706/frc/robot/Robot.java
@@ -79,11 +79,11 @@ public class Robot extends TimedRobot {
         }
 
         commands = new Command[]{
-                OI.getInstance().driveCommand,                                             // 0
+                null,                                                                      // 0
                 null,                                                                      // 1
                 null,                                                                      // 2
-                OI.getInstance().driveCommand,                                             // 3
-                OI.getInstance().driveCommand,                                             // 4
+                null,                                                                      // 3
+                null,                                                                      // 4
                 new DriveOffHab(),                                                         // 5
                 new LevelOneCentreHatch(),                                                 // 6
         };


### PR DESCRIPTION
I don't really see a point in having the drive command listed as an autonomous mode.
Maybe there is a reason @eandr127 that I don't know about.

## Summary of Changes
- Remove drive command from autonomous modes.

## Testing Performed
**Environment**: Yet to be tested. Will update once tested.

