### PR TITLE
Remove auto intake cargo, slow down intake

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/OI.java
+++ b/src/main/java/ca/team2706/frc/robot/OI.java
@@ -124,8 +124,6 @@ public class OI {
         LiftPosition position = new LiftPosition();
         button.whenHeld(new EjectConditional(position));
         button.whenReleased(new AfterEjectConditional(position::getPosition));
-        new FluidButton(controlStick, Config.AUTO_INTAKE_CARGO_BINDING)
-                .whenHeld(new AutoIntakeCargo());
         new FluidButton(controlStick, Config.TOGGLE_RING_LIGHT_BINDING)
                 .whenPressed(new ToggleRingLight());
         new FluidButton(controlStick, Config.SLIGHTLY_LIFT_LIFT_BINDING)
@@ -134,7 +132,8 @@ public class OI {
         // ---- Driver controls ----
 
         // The button to use to interrupt the robots current command
-        new FluidButton(driverStick, Config.INTERRUPT_BUTTON).whenPressed(new InstantCommand(Robot::interruptCurrentCommand));
+        new FluidButton(driverStick, Config.INTERRUPT_BUTTON)
+                .whenPressed(new InstantCommand(Robot::interruptCurrentCommand));
         new FluidButton(driverStick, Config.DRIVER_ASSIST_VISION_CARGO_AND_LOADING_BINDING)
                 .whenPressed(new DriverAssistVision(true, false));
         new FluidButton(driverStick, Config.DRIVER_ASSIST_VISION_ROCKET_BINDING)

--- a/src/main/java/ca/team2706/frc/robot/commands/intake/cargo/RunIntakeOnJoystick.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/intake/cargo/RunIntakeOnJoystick.java
@@ -45,7 +45,7 @@ public class RunIntakeOnJoystick extends Command {
 
     @Override
     public void execute() {
-        double speed = controller.getRawAxis(triggerAxis);
+        double speed = controller.getRawAxis(triggerAxis) * 0.7;
         if (forward) {
             Intake.getInstance().runIntakeForward(speed);
         } else {


### PR DESCRIPTION
The operator (me) didn't like auto intake cargo, and it was just taking up a button and making
the operator (me) use it instead of manual.

Also slowed down intaking on manual because it was a little too fast.

## Summary of Changes
- Slow down intake/exhale cargo
- Remove binding to auto intake cargo (freeing up RB button)
- Add newline in one small spot.

## Testing Performed
**Environment**: Tested on competition robot.

