### PR TITLE
Remove override lift old bindings

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/config/Config.java
+++ b/src/main/java/ca/team2706/frc/robot/config/Config.java
@@ -249,8 +249,6 @@ public class Config {
             MOVE_LIFT_BINDING = constant("move-lift-binding", XboxValue.XBOX_LEFT_STICK_Y.getNTString()),
             LIFT_ARMS_BINDING = constant("lift-arms-binding", XboxValue.XBOX_A_BUTTON.getNTString()),
             LOWER_ARMS_BINDING = constant("lower-arms-binding", XboxValue.XBOX_Y_BUTTON.getNTString()),
-            OVERRIDE_LIFT_DOWN_BINDING = constant("override-lift-down-binding", XboxValue.XBOX_B_BUTTON.getNTString()),
-            OVERRIDE_LIFT_UP_BINDING = constant("override-lift-up-binding", XboxValue.XBOX_X_BUTTON.getNTString()),
             MANUAL_PISTON_BINDING = constant("manual-plunger-toggle", XboxValue.XBOX_RIGHT_AXIS_BUTTON.getNTString()),
             EJECT_BINDING = constant("eject-multi-purpose-binding", XboxValue.XBOX_RB_BUTTON.getNTString()),
             AUTO_INTAKE_CARGO_BINDING = constant("auto-intake-cargo-binding", XboxValue.XBOX_LB_BUTTON.getNTString()),

--- a/src/main/java/ca/team2706/frc/robot/input/FluidTrigger.java
+++ b/src/main/java/ca/team2706/frc/robot/input/FluidTrigger.java
@@ -20,6 +20,7 @@ public abstract class FluidTrigger extends ETrigger {
      *
      * @param bindings The fluid constant bindings.
      */
+    @SafeVarargs
     public FluidTrigger(FluidConstant<String>... bindings) {
         if (bindings == null || bindings.length <= 0) {
             throw new IllegalArgumentException("Bindings cannot be null or empty for FluidTrigger.");

--- a/src/test/java/ca/team2706/frc/robot/commands/drivebase/StraightDriveGyroTest.java
+++ b/src/test/java/ca/team2706/frc/robot/commands/drivebase/StraightDriveGyroTest.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import mockit.*;
 import org.junit.Before;
 import org.junit.Test;
+import util.Util;
 
 import static org.junit.Assert.*;
 
@@ -65,6 +66,8 @@ public class StraightDriveGyroTest {
             talon.getSensorCollection();
             result = sensorCollection;
         }};
+
+        Util.resetSubsystems();
     }
 
     /**

--- a/src/test/java/ca/team2706/frc/robot/commands/drivebase/StraightDriveTest.java
+++ b/src/test/java/ca/team2706/frc/robot/commands/drivebase/StraightDriveTest.java
@@ -17,6 +17,7 @@ import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import mockit.*;
 import org.junit.Before;
 import org.junit.Test;
+import util.Util;
 
 import static org.junit.Assert.*;
 
@@ -55,11 +56,13 @@ public class StraightDriveTest {
     private SensorCollection sensorCollection;
 
     @Before
-    public void setUp() {
+    public void setUp() throws NoSuchFieldException, IllegalAccessException {
         new Expectations() {{
             talon.getSensorCollection();
             result = sensorCollection;
         }};
+
+        Util.resetSubsystems();
     }
 
     /**


### PR DESCRIPTION
There were some old bindings that existed for overriding the lift.
Removed them.

## Summary of Changes
- Remove X and B bindings for overriding lift, since it now uses the left stick press down.

## Testing Performed
**Environment**: None
I verified that the variables that I removed had no references anywhere. They have already been tested while not there, they somehow made their way back into master.

