### PR TITLE
Pneumatic Piston and Pneumatic Controller overhaul

### DIFF
--- a/src/main/java/ca/team2706/frc/robot/commands/climber/MoveBackClimberPistons.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/climber/MoveBackClimberPistons.java
@@ -1,23 +1,16 @@
 package ca.team2706.frc.robot.commands.climber;
 
+import ca.team2706.frc.robot.commands.pneumatics.PneumaticController;
 import ca.team2706.frc.robot.config.Config;
 import ca.team2706.frc.robot.pneumatics.PneumaticState;
 import ca.team2706.frc.robot.subsystems.ClimberPneumatics;
-import edu.wpi.first.wpilibj.command.TimedCommand;
 
 import java.util.function.Function;
 
 /**
  * Command for moving the climber pistons, either in or out.
  */
-public class MoveBackClimberPistons extends TimedCommand {
-
-    private Function<PneumaticState, PneumaticState> desiredState;
-
-    /**
-     * True if the pneumatics are already in position, false otherwise.
-     */
-    private boolean isAlreadyInPosition;
+public class MoveBackClimberPistons extends PneumaticController {
 
     /**
      * Constructs the command for moving climber pistons.
@@ -26,31 +19,11 @@ public class MoveBackClimberPistons extends TimedCommand {
      *                     expected return is the desired state.
      */
     public MoveBackClimberPistons(Function<PneumaticState, PneumaticState> desiredState) {
-        super(Config.CLIMBER_BACK_PISTONS_ON_TIME);
+        super(ClimberPneumatics.getInstance()::moveBackPiston,
+                desiredState,
+                ClimberPneumatics.getInstance()::getBackState,
+                Config.CLIMBER_BACK_PISTONS_ON_TIME,
+                ClimberPneumatics.getInstance()::stopPneumatics);
         requires(ClimberPneumatics.getInstance());
-
-        this.desiredState = desiredState;
-    }
-
-    @Override
-    protected void initialize() {
-        final PneumaticState oldState = ClimberPneumatics.getInstance().getBackState();
-        final PneumaticState newState = desiredState.apply(oldState);
-
-        isAlreadyInPosition = newState == oldState;
-
-        ClimberPneumatics.getInstance().moveBackPiston(newState);
-    }
-
-    @Override
-    protected boolean isFinished() {
-        // Complete when the timed command thinks we're done or if the pistons are already where we want them.
-        return super.isFinished() || isAlreadyInPosition;
-    }
-
-    @Override
-    protected void end() {
-        ClimberPneumatics.getInstance().stopPneumatics();
-        isAlreadyInPosition = false;
     }
 }

--- a/src/main/java/ca/team2706/frc/robot/commands/climber/MoveFrontClimberPistons.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/climber/MoveFrontClimberPistons.java
@@ -1,23 +1,16 @@
 package ca.team2706.frc.robot.commands.climber;
 
+import ca.team2706.frc.robot.commands.pneumatics.PneumaticController;
 import ca.team2706.frc.robot.config.Config;
 import ca.team2706.frc.robot.pneumatics.PneumaticState;
 import ca.team2706.frc.robot.subsystems.ClimberPneumatics;
-import edu.wpi.first.wpilibj.command.TimedCommand;
 
 import java.util.function.Function;
 
 /**
  * Command for moving the climber pistons, either in or out.
  */
-public class MoveFrontClimberPistons extends TimedCommand {
-
-    private Function<PneumaticState, PneumaticState> desiredState;
-
-    /**
-     * True if the pneumatics are already in position, false otherwise.
-     */
-    private boolean isAlreadyInPosition;
+public class MoveFrontClimberPistons extends PneumaticController {
 
     /**
      * Constructs the command for moving climber pistons.
@@ -26,31 +19,11 @@ public class MoveFrontClimberPistons extends TimedCommand {
      *                     expected return is the desired state.
      */
     public MoveFrontClimberPistons(Function<PneumaticState, PneumaticState> desiredState) {
-        super(Config.CLIMBER_FRONT_PISTONS_ON_TIME);
+        super(ClimberPneumatics.getInstance()::moveFrontPiston,
+                desiredState,
+                ClimberPneumatics.getInstance()::getFrontState,
+                Config.CLIMBER_FRONT_PISTONS_ON_TIME,
+                ClimberPneumatics.getInstance()::stopPneumatics);
         requires(ClimberPneumatics.getInstance());
-
-        this.desiredState = desiredState;
-    }
-
-    @Override
-    protected void initialize() {
-        final PneumaticState oldState = ClimberPneumatics.getInstance().getFrontState();
-        final PneumaticState newState = desiredState.apply(oldState);
-
-        isAlreadyInPosition = newState == oldState;
-
-        ClimberPneumatics.getInstance().moveFrontPiston(newState);
-    }
-
-    @Override
-    protected boolean isFinished() {
-        // Complete when the timed command thinks we're done or if the pistons are already where we want them.
-        return super.isFinished() || isAlreadyInPosition;
-    }
-
-    @Override
-    protected void end() {
-        ClimberPneumatics.getInstance().stopPneumatics();
-        isAlreadyInPosition = false;
     }
 }

--- a/src/main/java/ca/team2706/frc/robot/commands/intake/arms/LowerArms.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/intake/arms/LowerArms.java
@@ -1,40 +1,16 @@
 package ca.team2706.frc.robot.commands.intake.arms;
 
-import ca.team2706.frc.robot.config.Config;
-import ca.team2706.frc.robot.subsystems.Pneumatics;
-import edu.wpi.first.wpilibj.command.TimedCommand;
+import ca.team2706.frc.robot.pneumatics.PneumaticState;
 
 /**
- * Lowers the intake arms in preparation for dealing with cargo
+ * Command for lowering the intake arms.
  */
-public class LowerArms extends TimedCommand {
-
-    private Pneumatics.IntakeMode previousIntakeState;
+public class LowerArms extends MoveArms {
 
     /**
-     * Constructs a new command to lower the intake arms in preparation for handling cargo.
+     * Constructs the command to lower the intake arms.
      */
     public LowerArms() {
-        super(Config.INTAKE_ARMS_DELAY);
-        requires(Pneumatics.getInstance());
-    }
-
-    @Override
-    protected void initialize() {
-        super.initialize();
-        previousIntakeState = Pneumatics.getInstance().getMode();
-        Pneumatics.getInstance().lowerArms();
-    }
-
-    @Override
-    protected boolean isFinished() {
-        // We're done if time command is done (thus the or statement) or if the arms were in a good position to start.
-        return super.isFinished() || previousIntakeState == Pneumatics.IntakeMode.CARGO;
-    }
-
-    @Override
-    protected void end() {
-        super.end();
-        Pneumatics.getInstance().stopArmsPneumatics();
+        super(() -> PneumaticState.DEPLOYED);
     }
 }

--- a/src/main/java/ca/team2706/frc/robot/commands/intake/arms/MoveArms.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/intake/arms/MoveArms.java
@@ -19,8 +19,9 @@ public class MoveArms extends PneumaticController {
      *                             The expected return is the desired position for the arms.
      */
     public MoveArms(final Supplier<PneumaticState> desiredStateProvider) {
-        super(Pneumatics.getInstance()::raiseArms, Pneumatics.getInstance()::lowerArms,
-                pneumaticState -> desiredStateProvider.get(), null, Config.INTAKE_ARMS_DELAY,
+        super(Pneumatics.getInstance()::moveArms,
+                pneumaticState -> desiredStateProvider.get(), Pneumatics.getInstance()::getArmsState,
+                Config.INTAKE_ARMS_DELAY,
                 Pneumatics.getInstance()::stopArmsPneumatics);
         requires(Pneumatics.getInstance());
     }

--- a/src/main/java/ca/team2706/frc/robot/commands/intake/arms/MoveArms.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/intake/arms/MoveArms.java
@@ -1,0 +1,27 @@
+package ca.team2706.frc.robot.commands.intake.arms;
+
+import ca.team2706.frc.robot.commands.pneumatics.PneumaticController;
+import ca.team2706.frc.robot.config.Config;
+import ca.team2706.frc.robot.pneumatics.PneumaticState;
+import ca.team2706.frc.robot.subsystems.Pneumatics;
+
+import java.util.function.Supplier;
+
+/**
+ * Function for manipulating the intake arms pneumatics.
+ */
+public class MoveArms extends PneumaticController {
+
+    /**
+     * Constructs a command for moving the intake arms.
+     *
+     * @param desiredStateProvider The provider of the desired state of the pneumatics.
+     *                             The expected return is the desired position for the arms.
+     */
+    public MoveArms(final Supplier<PneumaticState> desiredStateProvider) {
+        super(Pneumatics.getInstance()::raiseArms, Pneumatics.getInstance()::lowerArms,
+                pneumaticState -> desiredStateProvider.get(), null, Config.INTAKE_ARMS_DELAY,
+                Pneumatics.getInstance()::stopArmsPneumatics);
+        requires(Pneumatics.getInstance());
+    }
+}

--- a/src/main/java/ca/team2706/frc/robot/commands/intake/arms/MovePlunger.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/intake/arms/MovePlunger.java
@@ -1,9 +1,9 @@
 package ca.team2706.frc.robot.commands.intake.arms;
 
+import ca.team2706.frc.robot.commands.pneumatics.PneumaticController;
 import ca.team2706.frc.robot.config.Config;
 import ca.team2706.frc.robot.pneumatics.PneumaticState;
 import ca.team2706.frc.robot.subsystems.Pneumatics;
-import edu.wpi.first.wpilibj.command.TimedCommand;
 
 import java.util.function.Function;
 
@@ -11,48 +11,21 @@ import java.util.function.Function;
  * Command for moving the plunger, either retracting it or expanding it.
  * Timeout is to ensure that the command ends when the plunger is in the right position.
  */
-public class MovePlunger extends TimedCommand {
-    private boolean isAlreadyInPosition = false;
-
-
-    private Function<PneumaticState, PneumaticState> newState;
+public class MovePlunger extends PneumaticController {
 
     /**
      * @param newState Function for determining the desired new state of the plunger based on its current state.
      */
     public MovePlunger(final Function<PneumaticState, PneumaticState> newState) {
-        super(Config.PLUNGER_TIMEOUT);
+        super(Pneumatics.getInstance()::movePlunger, newState, Pneumatics.getInstance()::getPlungerState,
+                Config.PLUNGER_TIMEOUT, Pneumatics.getInstance()::stopPlunger);
         requires(Pneumatics.getInstance());
-        this.newState = newState;
     }
 
     /**
-     * Constructs a new plunger mover that toggles the plunger.
+     * Constructs a move plunger command which will toggle the plunger's current position.
      */
     public MovePlunger() {
         this(PneumaticState::getOpposite);
-    }
-
-    @Override
-    protected void initialize() {
-        super.initialize();
-        final PneumaticState oldState = Pneumatics.getInstance().getPlungerState();
-        final PneumaticState newState = this.newState.apply(oldState);
-
-        isAlreadyInPosition = oldState == newState;
-        Pneumatics.getInstance().movePlunger(newState);
-    }
-
-    @Override
-    protected boolean isFinished() {
-        // We're done already if the plunger is already in the desired position.
-        return super.isFinished() || isAlreadyInPosition;
-    }
-
-    @Override
-    protected void end() {
-        super.end();
-        Pneumatics.getInstance().stopPlunger();
-        isAlreadyInPosition = false;
     }
 }

--- a/src/main/java/ca/team2706/frc/robot/commands/intake/arms/RaiseArms.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/intake/arms/RaiseArms.java
@@ -1,40 +1,16 @@
 package ca.team2706.frc.robot.commands.intake.arms;
 
-import ca.team2706.frc.robot.config.Config;
-import ca.team2706.frc.robot.subsystems.Pneumatics;
-import edu.wpi.first.wpilibj.command.TimedCommand;
+import ca.team2706.frc.robot.pneumatics.PneumaticState;
 
 /**
- * Raises the intake arms to prepare for handling hatches.
+ * Command for raising the intake arms using pneumatics.
  */
-public class RaiseArms extends TimedCommand {
-
-    private Pneumatics.IntakeMode previousIntakeState;
+public class RaiseArms extends MoveArms {
 
     /**
-     * Constructs a new command to raise the intake arms in preparation for handling hatches.
+     * Constructs a command for raising the arm pneumatics.
      */
     public RaiseArms() {
-        super(Config.INTAKE_ARMS_DELAY);
-        requires(Pneumatics.getInstance());
-    }
-
-    @Override
-    protected void initialize() {
-        super.initialize();
-        previousIntakeState = Pneumatics.getInstance().getMode();
-        Pneumatics.getInstance().raiseArms();
-    }
-
-    @Override
-    protected boolean isFinished() {
-        // We're done if the timed command is done (thus the or statement) or if the arms were in hatch mode to start.
-        return super.isFinished() || previousIntakeState == Pneumatics.IntakeMode.HATCH;
-    }
-
-    @Override
-    protected void end() {
-        super.end();
-        Pneumatics.getInstance().stopArmsPneumatics();
+        super(() -> PneumaticState.STOWED);
     }
 }

--- a/src/main/java/ca/team2706/frc/robot/commands/pneumatics/PneumaticController.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/pneumatics/PneumaticController.java
@@ -22,6 +22,43 @@ public class PneumaticController extends TimedCommand {
     private boolean isAlreadyInPosition;
 
     /**
+     * Set to true to always move the piston, even if it is already in the desired position.
+     */
+    private boolean alwaysMovePiston;
+
+    /**
+     * Constructs a generic pneumatic controller command for controlling a pneumatic piston.
+     *
+     * @param moveFunction         The function for moving the piston, which accepts an argument of the piston's
+     *                             desired state.
+     *                             Cannot be null.
+     * @param desiredStateProvider The supplier of the desired state of the piston.
+     *                             The provided argument is the current state of the piston.
+     *                             The expected return value is the desired state of the piston.
+     *                             Cannot be null or return null.
+     * @param currentStateProvider The supplier for the piston's current state. Can be null, but must not return null.
+     * @param moveTime             The time that should be allotted for moving the piston, if it is necessary to move it.
+     * @param stopFunction         The function for turning off the pneumatics. Cannot be null.
+     * @param alwaysMovePiston     True to continue with the command and move the piston even if it is already
+     *                             in the desired position.
+     */
+    public PneumaticController(final Consumer<PneumaticState> moveFunction,
+                               final Function<PneumaticState, PneumaticState> desiredStateProvider,
+                               final Supplier<PneumaticState> currentStateProvider,
+                               final double moveTime,
+                               final Runnable stopFunction,
+                               final boolean alwaysMovePiston) {
+        super(moveTime);
+
+        this.moveFunction = Objects.requireNonNull(moveFunction, "Move Function cannot be null.");
+        this.desiredStateProvider =
+                Objects.requireNonNull(desiredStateProvider, "Desired state supplier cannot be null.");
+        this.currentStateSupplier = currentStateProvider;
+        this.stopFunction = Objects.requireNonNull(stopFunction, "Stop function cannot be null.");
+        setAlwaysMovePiston(alwaysMovePiston);
+    }
+
+    /**
      * Constructs a generic pneumatic controller command for controlling a pneumatic piston.
      *
      * @param moveFunction         The function for moving the piston, which accepts an argument of the piston's
@@ -40,13 +77,7 @@ public class PneumaticController extends TimedCommand {
                                final Supplier<PneumaticState> currentStateProvider,
                                final double moveTime,
                                final Runnable stopFunction) {
-        super(moveTime);
-
-        this.moveFunction = Objects.requireNonNull(moveFunction, "Move Function cannot be null.");
-        this.desiredStateProvider =
-                Objects.requireNonNull(desiredStateProvider, "Desired state supplier cannot be null.");
-        this.currentStateSupplier = currentStateProvider;
-        this.stopFunction = Objects.requireNonNull(stopFunction, "Stop function cannot be null.");
+        this(moveFunction, desiredStateProvider, currentStateProvider, moveTime, stopFunction, false);
     }
 
     /**
@@ -86,6 +117,45 @@ public class PneumaticController extends TimedCommand {
     }
 
     /**
+     * Constructs a generic pneumatic controller command for controlling a pneumatic piston.
+     *
+     * @param deployFunction       The function for deploying (extending) the pneumatic piston.
+     *                             Can be null if deploying isn't desired behaviour.
+     * @param stowFunction         The function for retracting (stowing) the pneumatic piston.
+     *                             Can be null if stowing isn't desired behaviour.
+     * @param desiredStateProvider The supplier of the desired state of the piston.
+     *                             The provided argument is the current state of the piston.
+     *                             The expected return value is the desired state of the piston.
+     * @param currentStateProvider The supplier for the piston's current state.
+     * @param moveTime             The time that should be allotted for moving the piston, if it is necessary to move it.
+     * @param stopFunction         The function for turning off the pneumatics.
+     * @param alwaysMovePiston     True to continue with the command and move the piston even if it is already
+     *                             in the desired position.
+     */
+    public PneumaticController(final Runnable deployFunction,
+                               final Runnable stowFunction,
+                               final Function<PneumaticState, PneumaticState> desiredStateProvider,
+                               final Supplier<PneumaticState> currentStateProvider,
+                               final double moveTime,
+                               final Runnable stopFunction,
+                               final boolean alwaysMovePiston) {
+        this(pneumaticState -> {
+            switch (pneumaticState) {
+                case DEPLOYED:
+                    if (deployFunction != null) {
+                        deployFunction.run();
+                    }
+                    break;
+                case STOWED:
+                    if (stowFunction != null) {
+                        stowFunction.run();
+                    }
+                    break;
+            }
+        }, desiredStateProvider, currentStateProvider, moveTime, stopFunction, alwaysMovePiston);
+    }
+
+    /**
      * Constructs a pneumatic controller command for moving a pneumatic piston.
      *
      * @param moveFunction         The function for moving the piston, which accepts an argument of the piston's
@@ -104,6 +174,26 @@ public class PneumaticController extends TimedCommand {
         this(moveFunction, desiredStateSupplier, null, moveTime, stopFunction);
     }
 
+    /**
+     * Determines if this command is set to always move the piston, even if
+     * it is in the correct position.
+     *
+     * @return True if the command will always move the piston, false otherwise.
+     */
+    public boolean willAlwaysMovePiston() {
+        return alwaysMovePiston;
+    }
+
+    /**
+     * Sets whether or not the command will always move the piston.
+     *
+     * @param alwaysMovePiston True to move the piston even if it is in position already (and thereby
+     *                         making the command delay if the piston is in its correct position), false otherwise.
+     */
+    public void setAlwaysMovePiston(boolean alwaysMovePiston) {
+        this.alwaysMovePiston = alwaysMovePiston;
+    }
+
 
     @Override
     protected void initialize() {
@@ -113,16 +203,15 @@ public class PneumaticController extends TimedCommand {
         final PneumaticState desiredState = desiredStateProvider.apply(previousState);
 
         isAlreadyInPosition = previousState == desiredState;
-        moveFunction.accept(desiredState);
+
+        if (willAlwaysMovePiston() || !isAlreadyInPosition) {
+            moveFunction.accept(desiredState);
+        }
     }
 
     @Override
     protected boolean isFinished() {
-        /*
-        TODO if the piston is already in position, it will be turned on and then off instantaneously.
-        Need to determine what the desired behaviour for this is.
-        */
-        return super.isFinished() || isAlreadyInPosition;
+        return super.isFinished() || (!willAlwaysMovePiston() && isAlreadyInPosition);
     }
 
     @Override

--- a/src/main/java/ca/team2706/frc/robot/commands/pneumatics/PneumaticController.java
+++ b/src/main/java/ca/team2706/frc/robot/commands/pneumatics/PneumaticController.java
@@ -1,0 +1,105 @@
+package ca.team2706.frc.robot.commands.pneumatics;
+
+import ca.team2706.frc.robot.pneumatics.PneumaticState;
+import edu.wpi.first.wpilibj.command.TimedCommand;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Generic class for controlling a pneumatic piston (something controlled with pneumatics
+ * which has two states: deployed and stowed).
+ */
+public class PneumaticController extends TimedCommand {
+
+
+    private final Consumer<PneumaticState> moveFunction;
+    private final Function<PneumaticState, PneumaticState> desiredStateProvider;
+    private final Supplier<PneumaticState> currentStateSupplier;
+    private final Runnable stopFunction;
+    private boolean isAlreadyInPosition;
+
+    /**
+     * Constructs a generic pneumatic controller command for controlling a pneumatic piston.
+     *
+     * @param moveFunction         The function for moving the piston, which accepts an argument of the piston's
+     *                             desired state.
+     * @param desiredStateProvider The supplier of the desired state of the piston.
+     *                             The provided argument is the current state of the piston.
+     *                             The expected return value is the desired state of the piston.
+     * @param currentStateProvider The supplier for the piston's current state.
+     * @param moveTime             The time that should be allotted for moving the piston, if it is necessary to move it.
+     * @param stopFunction         The function for turning off the pneumatics.
+     */
+    public PneumaticController(final Consumer<PneumaticState> moveFunction,
+                               final Function<PneumaticState, PneumaticState> desiredStateProvider,
+                               final Supplier<PneumaticState> currentStateProvider,
+                               final double moveTime,
+                               final Runnable stopFunction) {
+        super(moveTime);
+
+        this.moveFunction = moveFunction;
+        this.desiredStateProvider = desiredStateProvider;
+        this.currentStateSupplier = currentStateProvider;
+        this.stopFunction = stopFunction;
+    }
+
+    /**
+     * Constructs a generic pneumatic controller command for controlling a pneumatic piston.
+     *
+     * @param deployFunction       The function for deploying (extending) the pneumatic piston.
+     * @param stowFunction         The function for retracting (stowing) the pneumatic piston.
+     * @param desiredStateProvider The supplier of the desired state of the piston.
+     *                             The provided argument is the current state of the piston.
+     *                             The expected return value is the desired state of the piston.
+     * @param currentStateProvider The supplier for the piston's current state.
+     * @param moveTime             The time that should be allotted for moving the piston, if it is necessary to move it.
+     * @param stopFunction         The function for turning off the pneumatics.
+     */
+    public PneumaticController(final Runnable deployFunction,
+                               final Runnable stowFunction,
+                               final Function<PneumaticState, PneumaticState> desiredStateProvider,
+                               final Supplier<PneumaticState> currentStateProvider,
+                               final double moveTime,
+                               final Runnable stopFunction) {
+        this(pneumaticState -> {
+            switch (pneumaticState) {
+                case DEPLOYED:
+                    deployFunction.run();
+                    break;
+                case STOWED:
+                    stowFunction.run();
+                    break;
+            }
+        }, desiredStateProvider, currentStateProvider, moveTime, stopFunction);
+    }
+
+
+    @Override
+    protected void initialize() {
+        super.initialize();
+
+        final PneumaticState previousState = currentStateSupplier.get();
+        final PneumaticState desiredState = desiredStateProvider.apply(previousState);
+
+        isAlreadyInPosition = previousState == desiredState;
+        moveFunction.accept(desiredState);
+    }
+
+    @Override
+    protected boolean isFinished() {
+        /*
+        TODO if the piston is already in position, it will be turned on and then off instantaneously.
+        Need to determine what the desired behaviour for this is.
+        */
+        return super.isFinished() || isAlreadyInPosition;
+    }
+
+    @Override
+    protected void end() {
+        super.end();
+        stopFunction.run();
+        this.isAlreadyInPosition = false;
+    }
+}

--- a/src/main/java/ca/team2706/frc/robot/config/Config.java
+++ b/src/main/java/ca/team2706/frc/robot/config/Config.java
@@ -73,8 +73,8 @@ public class Config {
     public static final int
             INTAKE_MOTOR_ID = robotSpecific(6, 6, 6),
             CARGO_IR_SENSOR_ID = robotSpecific(1, 1, 1),
-            INTAKE_LIFT_SOLENOID_FORWARD_ID = robotSpecific(2, 2, 2),
-            INTAKE_LIFT_SOLENOID_BACKWARD_ID = robotSpecific(3, 3, 3),
+            INTAKE_LIFT_SOLENOID_FORWARD_ID = robotSpecific(3, 3, 3),
+            INTAKE_LIFT_SOLENOID_BACKWARD_ID = robotSpecific(2, 2, 2),
             HATCH_EJECTOR_SOLENOID_FORWARD_ID = robotSpecific(1, 0, 0),
             HATCH_EJECTOR_SOLENOID_BACKWARD_ID = robotSpecific(0, 1, 1);
 

--- a/src/main/java/ca/team2706/frc/robot/pneumatics/PneumaticPiston.java
+++ b/src/main/java/ca/team2706/frc/robot/pneumatics/PneumaticPiston.java
@@ -102,6 +102,7 @@ public class PneumaticPiston extends DoubleSolenoid {
 
     /**
      * Sets the state of the pneumatic piston without moving it.
+     *
      * @param state The state of the pneumatic piston.
      *              Must be one of {@link PneumaticState#STOWED} or {@link PneumaticState#DEPLOYED} or null for unknown.
      */

--- a/src/main/java/ca/team2706/frc/robot/pneumatics/PneumaticPiston.java
+++ b/src/main/java/ca/team2706/frc/robot/pneumatics/PneumaticPiston.java
@@ -1,6 +1,7 @@
 package ca.team2706.frc.robot.pneumatics;
 
 import edu.wpi.first.wpilibj.DoubleSolenoid;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 /**
  * Class for representing a pneumatic piston, a device which goes in or out
@@ -31,17 +32,16 @@ public class PneumaticPiston extends DoubleSolenoid {
      * @param forwardChannel {@link DoubleSolenoid#DoubleSolenoid(int, int)}
      * @param reverseChannel {@link DoubleSolenoid#DoubleSolenoid(int, int)}
      * @param startPosition  The default starting position for the pneumatic piston, either in or out.
-     *                       Must be one of {@link PneumaticState#DEPLOYED} or {@link PneumaticState#STOWED}
+     *                       Must be one of {@link PneumaticState#DEPLOYED} or {@link PneumaticState#STOWED},
+     *                       or null if the state is unknown, in which case the state can be set with
+     *                       {@link #forceSetState(PneumaticState)} or will be set when the piston is moved.
      * @param checkState     True to not call the double solenoid if the pneumatic piston is already
      *                       in the desired position, false otherwise.
      */
     public PneumaticPiston(int forwardChannel, int reverseChannel, PneumaticState startPosition, boolean checkState) {
         super(forwardChannel, reverseChannel);
 
-        if (startPosition != PneumaticState.STOWED && startPosition != PneumaticState.DEPLOYED) {
-            throw new IllegalArgumentException("Start position of a pneumatic piston must either be stowed or deployed");
-        }
-        this.currentState = startPosition;
+        forceSetState(startPosition);
         this.checkState = checkState;
     }
 
@@ -97,5 +97,35 @@ public class PneumaticPiston extends DoubleSolenoid {
      */
     public PneumaticState getState() {
         return currentState;
+    }
+
+    /**
+     * Sets the state of the pneumatic piston without moving it.
+     * @param state The state of the pneumatic piston.
+     *              Must be one of {@link PneumaticState#STOWED} or {@link PneumaticState#DEPLOYED} or null for unknown.
+     */
+    public void forceSetState(final PneumaticState state) {
+        if (state != PneumaticState.STOWED && state != PneumaticState.DEPLOYED && state != null) {
+            throw new IllegalArgumentException("Start position of a pneumatic piston must either be stowed or " +
+                    "deployed or null for unknown.");
+        } else {
+            currentState = state;
+        }
+    }
+
+    @Override
+    public void initSendable(SendableBuilder builder) {
+        builder.addStringProperty("State", () -> {
+            PneumaticState state = getState();
+            String stringState;
+            if (state == null) {
+                stringState = "NULL";
+            } else {
+                stringState = state.toString();
+            }
+
+            return stringState;
+        }, s -> set(PneumaticState.valueOf(s)));
+        super.initSendable(builder);
     }
 }

--- a/src/main/java/ca/team2706/frc/robot/pneumatics/PneumaticPiston.java
+++ b/src/main/java/ca/team2706/frc/robot/pneumatics/PneumaticPiston.java
@@ -22,7 +22,7 @@ public class PneumaticPiston extends DoubleSolenoid {
      * @param reverseChannel {@link DoubleSolenoid#DoubleSolenoid(int, int)}
      * @param startPosition  The default starting position for the pneumatic piston, either in or out.
      */
-    public PneumaticPiston(int forwardChannel, int reverseChannel, PneumaticState startPosition) {
+    public PneumaticPiston(final int forwardChannel, final int reverseChannel, final PneumaticState startPosition) {
         this(forwardChannel, reverseChannel, startPosition, false);
     }
 
@@ -38,11 +38,12 @@ public class PneumaticPiston extends DoubleSolenoid {
      * @param checkState     True to not call the double solenoid if the pneumatic piston is already
      *                       in the desired position, false otherwise.
      */
-    public PneumaticPiston(int forwardChannel, int reverseChannel, PneumaticState startPosition, boolean checkState) {
+    public PneumaticPiston(final int forwardChannel, final int reverseChannel,
+                           final PneumaticState startPosition, final boolean checkState) {
         super(forwardChannel, reverseChannel);
+        this.checkState = checkState;
 
         forceSetState(startPosition);
-        this.checkState = checkState;
     }
 
 

--- a/src/main/java/ca/team2706/frc/robot/subsystems/Pneumatics.java
+++ b/src/main/java/ca/team2706/frc/robot/subsystems/Pneumatics.java
@@ -9,6 +9,7 @@ import ca.team2706.frc.robot.pneumatics.PneumaticPiston;
 import ca.team2706.frc.robot.pneumatics.PneumaticState;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 import edu.wpi.first.wpilibj.command.Subsystem;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 import java.util.function.Consumer;
 
@@ -150,6 +151,8 @@ public class Pneumatics extends Subsystem {
      */
     public void movePlunger(PneumaticState newState) {
         hatchEjectorSolenoid.set(newState);
+        // Update plunger state on dashboard.
+        SmartDashboard.putString("Plunger State", getPlungerState().toString());
     }
 
     /**
@@ -165,7 +168,7 @@ public class Pneumatics extends Subsystem {
      * @return True if the plunger is stowed, false otherwise.
      */
     public boolean isPlungerStowed() {
-        return hatchEjectorSolenoid.getState() == PneumaticState.STOWED;
+        return getPlungerState() == PneumaticState.STOWED;
     }
 
     /**

--- a/src/main/java/ca/team2706/frc/robot/subsystems/Pneumatics.java
+++ b/src/main/java/ca/team2706/frc/robot/subsystems/Pneumatics.java
@@ -55,7 +55,7 @@ public class Pneumatics extends Subsystem {
      * Constructs a new Pneumatics with default DoubleSolenoids.
      */
     private Pneumatics() {
-        this(new PneumaticPiston(Config.INTAKE_LIFT_SOLENOID_FORWARD_ID, Config.INTAKE_LIFT_SOLENOID_BACKWARD_ID, null), // TODO make sure null doesn't crash it.
+        this(new PneumaticPiston(Config.INTAKE_LIFT_SOLENOID_FORWARD_ID, Config.INTAKE_LIFT_SOLENOID_BACKWARD_ID, null),
                 new PneumaticPiston(Config.HATCH_EJECTOR_SOLENOID_FORWARD_ID, Config.HATCH_EJECTOR_SOLENOID_BACKWARD_ID, PneumaticState.STOWED));
     }
 

--- a/src/test/java/ca/team2706/frc/robot/config/ConfigTest.java
+++ b/src/test/java/ca/team2706/frc/robot/config/ConfigTest.java
@@ -13,6 +13,7 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.*;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import jaci.pathfinder.Pathfinder;
 import jaci.pathfinder.Trajectory;
 import mockit.Expectations;
@@ -99,6 +100,9 @@ public class ConfigTest {
 
     @Mocked
     private DigitalInput input;
+
+    @Mocked
+    private SmartDashboard dashboard;
 
     private boolean initialized = false;
 

--- a/src/test/java/ca/team2706/frc/robot/config/FluidConstantTest.java
+++ b/src/test/java/ca/team2706/frc/robot/config/FluidConstantTest.java
@@ -14,6 +14,7 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.*;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import jaci.pathfinder.Pathfinder;
 import jaci.pathfinder.Trajectory;
 import mockit.*;
@@ -36,6 +37,9 @@ public class FluidConstantTest {
 
     @Mocked
     private DigitalInput digitalInput;
+
+    @Mocked
+    private SmartDashboard dashboard;
 
     @Injectable
     private NetworkTable constantsTable;


### PR DESCRIPTION
Closes #163.

## Summary of Changes
- Switches commands for moving pneumatics to a general command to make things easier.
- Pneumatics on the subsystem side are controlled using a general class `PneumaticPiston` which allows for the same functionality as `DoubleSolenoid` but with the addition of keeping track of state and setting the piston to a new state rather than a value.
- Updated id values for the arms forward and reverse since the whole year we had it reversed a little bit.

## Testing Performed
**Environment**: Practice bot (and competition bot for some things too, during competition).
Tested moving all the mechanisms using the Pneumatic Piston class and the new pneumatic controllers, and everything performed consistently and nicely.

