### PR TITLE
Add mock for SmartDashboard in whenHeldTest

### DIFF
--- a/src/test/java/ca/team2706/frc/robot/input/EButtonTest.java
+++ b/src/test/java/ca/team2706/frc/robot/input/EButtonTest.java
@@ -11,6 +11,7 @@ import edu.wpi.first.wpilibj.*;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
@@ -70,6 +71,9 @@ public class EButtonTest {
 
     @Injectable
     private SensorCollection sensorCollection;
+
+    @Mocked
+    private SmartDashboard dashboard;
 
     @Before
     public void setUp() {


### PR DESCRIPTION
The SmartDashboard needed a mock statement in order to fix things.

## Summary of Changes
- Add mock to SmartDashboard in `EButtonTest` because [these tests](https://dev.azure.com/FRC2706/2019-2706%20Robot%20Code/_build/results?buildId=1159&view=ms.vss-test-web.build-test-results-tab&runId=3534&resultId=100075&paneView=debug) failed.

## Testing Performed
**Environment**: Online tests.

